### PR TITLE
feat: endpoint PATCH para alternar status ativo/inativo do produto

### DIFF
--- a/src/main/java/com/sedocefosse/backend/controller/AdminProductController.java
+++ b/src/main/java/com/sedocefosse/backend/controller/AdminProductController.java
@@ -7,6 +7,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -31,6 +32,15 @@ public class AdminProductController {
     public ResponseEntity<Product> createProduct(@RequestBody Product product) {
         Product createdProduct = productService.create(product);
         return new ResponseEntity<>(createdProduct, HttpStatus.CREATED);
+    }
+
+    @PatchMapping("/{id}/status")
+    public ResponseEntity<Product> toggleProductStatus(@PathVariable String id) {
+        Product updatedProduct = productService.toggleStatus(id);
+        if (updatedProduct == null) {
+            return ResponseEntity.notFound().build();
+        }
+        return ResponseEntity.ok(updatedProduct);
     }
   
 }

--- a/src/main/java/com/sedocefosse/backend/service/ProductService.java
+++ b/src/main/java/com/sedocefosse/backend/service/ProductService.java
@@ -19,4 +19,5 @@ public interface ProductService {
 
     List<CategoryDTO> getAllProductsGroupedByCategory();
 
+    Product toggleStatus(String id);
 }

--- a/src/main/java/com/sedocefosse/backend/service/ProductServiceImpl.java
+++ b/src/main/java/com/sedocefosse/backend/service/ProductServiceImpl.java
@@ -95,6 +95,17 @@ public class ProductServiceImpl implements ProductService {
         }
         return dto;
     }
+
+    @Override
+    public Product toggleStatus(String id) {
+        Optional<Product> optionalProduct = productRepository.findById(id);
+        if (optionalProduct.isEmpty()) {
+            return null;
+        }
+        Product product = optionalProduct.get();
+        product.setAtivo(!Boolean.TRUE.equals(product.getAtivo()));
+        return productRepository.save(product);
+    }
 }
 
 //Teste manual a ser feito no Postman


### PR DESCRIPTION
Implementa o controle de status (Ativo/Inativo) para produtos.

**O que foi feito**

- Criado endpoint PUT /admin/products/{id}/status
- Controller chama o service para alternar o status do produto
- Service busca o produto, altera o status (toggle) e salva no banco
- Retorna o produto atualizado após a alteração

**Como testar**

1. Chamar o endpoint PUT /admin/products/{id}/status passando o ID do produto
2. Verificar se o campo de status alterna entre Ativo e Inativo