### PR TITLE
feat: add AWS S3 integration for product images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,7 +100,6 @@ application-local.properties
 application-local.yml
 application-dev.properties
 application-dev.yml
-application-test.properties
 application-test.yml
 
 ### Database files ###

--- a/pom.xml
+++ b/pom.xml
@@ -145,6 +145,13 @@
             <version>2.6.0</version>
         </dependency>
 
+        
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>s3</artifactId>
+            <version>2.20.26</version>
+        </dependency>
+
     </dependencies>
 
 	<build>

--- a/seed/postgresql-init.sql
+++ b/seed/postgresql-init.sql
@@ -8,7 +8,6 @@ DROP TABLE IF EXISTS "produto_ingrediente" CASCADE;
 DROP TABLE IF EXISTS "produto" CASCADE;
 DROP TABLE IF EXISTS "estoque_insumos" CASCADE;
 DROP TABLE IF EXISTS "unidade" CASCADE;
-DROP TABLE IF EXISTS "user" CASCADE;
 drop table if exists "admin" cascade;
 
 CREATE TABLE "unidade" (
@@ -33,7 +32,8 @@ CREATE TABLE "produto" (
 "descricao" varchar,
 "valor" numeric,
 "imagem_url" varchar,
-"ativo" boolean
+"ativo" boolean,
+"quantidade" int
 );
 
 CREATE TABLE "produto_ingrediente" (
@@ -56,12 +56,6 @@ CREATE TABLE "cupom_produto" (
 "cupom_id" int,
 "produto_sku" varchar,
 PRIMARY KEY ("cupom_id", "produto_sku")
-);
-
-CREATE TABLE "user" (
-"id" varchar PRIMARY KEY,
-"nome" varchar,
-"telefone" varchar
 );
 
 CREATE TABLE "pedido" (
@@ -111,12 +105,10 @@ ALTER TABLE "produto_ingrediente" ADD FOREIGN KEY ("produto_sku") REFERENCES "pr
 ALTER TABLE "produto_ingrediente" ADD FOREIGN KEY ("ingrediente_id") REFERENCES "estoque_insumos" ("id");
 ALTER TABLE "cupom_produto" ADD FOREIGN KEY ("cupom_id") REFERENCES "cupom" ("id");
 ALTER TABLE "cupom_produto" ADD FOREIGN KEY ("produto_sku") REFERENCES "produto" ("sku");
-ALTER TABLE "pedido" ADD FOREIGN KEY ("cliente_id") REFERENCES "user" ("id");
 ALTER TABLE "pedido" ADD FOREIGN KEY ("cupom_id") REFERENCES "cupom" ("id");
 ALTER TABLE "pedido_item" ADD FOREIGN KEY ("pedido_id") REFERENCES "pedido" ("id");
 ALTER TABLE "pedido_item" ADD FOREIGN KEY ("produto_sku") REFERENCES "produto" ("sku");
 ALTER TABLE "avaliacao" ADD FOREIGN KEY ("pedido_id") REFERENCES "pedido" ("id");
-ALTER TABLE "avaliacao" ADD FOREIGN KEY ("cliente_id") REFERENCES "user" ("id");
 ALTER TABLE "historico_compra" ADD FOREIGN KEY ("id_insumo") REFERENCES "estoque_insumos" ("id");
 ALTER TABLE "historico_compra" ADD FOREIGN KEY ("id_unidade") REFERENCES "unidade" ("id");
 
@@ -125,11 +117,6 @@ INSERT INTO "unidade" ("nome", "base_preco_compra") VALUES
 ('KG', 1000.00),
 ('UN', 1.00),
 ('L', 1.00);
-
-INSERT INTO "user" ("id","nome", "telefone") VALUES
-('1','Alice Smith', '987654321'),
-('2','Bob Johnson', '555123456'),
-('3','Carlos Oliveira', '11998765432');
 
 INSERT INTO "admin" ("username", "email", "password", "role") VALUES
 ('admin_master', 'admin@email.com', '$2a$10$CKonyZomgg/CVkYBy.Ex9.stAr8SBerpSE8igTBlk5I..YRniz4ta', 'ROLE_OWNER');
@@ -153,15 +140,15 @@ INSERT INTO "estoque_insumos" ("nome", "id_unidade", "quantidade", "preco_compra
 ('Embalagem Individual para Cookie', 2, 500, 0.50, 100, true),
 ('Caixa para Bolo Pequeno', 2, 50, 3.00, 10, true);
 
-INSERT INTO "produto" ("sku", "nome", "descricao", "valor", "imagem_url", "ativo") VALUES
-('CK001', 'Cookie Clássico com Gotas de Chocolate', 'Massa amanteigada com baunilha e gotas de chocolate meio amargo.', 41.50, 'https://static.ifood-static.com.br/image/upload/t_medium/pratos/96aa4ce9-22d9-4993-8f81-01caf03c2d31/202506161754_8J5A_i.jpg', true),
-('CK002', 'Cookie Chocolate Branco', 'Prepare-se para uma verdadeira explosão de sabores com o nosso irresistível Cookie de chocolate branco! ', 15.50, 'https://static.ifood-static.com.br/image/upload/t_medium/pratos/96aa4ce9-22d9-4993-8f81-01caf03c2d31/202502272218_TE6C_i.jpg', true),
-('CK003', 'Cookie Dark Chocolate', 'Uma verdadeira explosão de sabores para os chocólatras de plantão! Nossa massa rica e intensa em cacau é a base perfeita para pedaços generosos de chocolate branco, ao leite e meio amargo, que se derretem delicadamente em cada mordida.', 52.50, 'https://static.ifood-static.com.br/image/upload/t_medium/pratos/96aa4ce9-22d9-4993-8f81-01caf03c2d31/202506161756_NB65_i.jpg', true),
-('CK004', 'Cookie Nozes com Doce de Leite', 'Mergulhe em um mundo de sabor com o nosso Cookie de Nozes com Doce de Leite, uma verdadeira obra-prima que vai encantar seus sentidos! ', 17.90, 'https://static.ifood-static.com.br/image/upload/t_medium/pratos/96aa4ce9-22d9-4993-8f81-01caf03c2d31/202506161909_5T2Y_i.jpg', true),
-('CK005', 'Cookie Romeu e Julieta', 'Uma releitura irresistível do clássico brasileiro!', 15.90, 'https://static.ifood-static.com.br/image/upload/t_medium/pratos/96aa4ce9-22d9-4993-8f81-01caf03c2d31/202506162235_DC6F_i.jpg', true),
-('BL001', 'Brownie com Nutella', 'Marmitinha de brownie com um delicioso recheio de Nutella', 20.90, 'https://static.ifood-static.com.br/image/upload/t_medium/pratos/96aa4ce9-22d9-4993-8f81-01caf03c2d31/202502272219_4KDY_i.jpg', true),
-('BL002', 'Bolo de Chocolate Intenso (fatia)', 'Fatia generosa de bolo de chocolate com cobertura de brigadeiro.', 35.00, 'https://static.ifood-static.com.br/image/upload/t_medium/pratos/96aa4ce9-22d9-4993-8f81-01caf03c2d31/202508091609_49LG_.jpeg', true),
-('BL003', 'Bolo de Cenoura com Chocolate (inteiro)', 'Bolo fofinho de cenoura com cobertura de chocolate. Serve 8 pessoas.', 25.00, 'https://static.ifood-static.com.br/image/upload/t_medium/pratos/96aa4ce9-22d9-4993-8f81-01caf03c2d31/202508091609_49LG_.jpeg', true);
+INSERT INTO "produto" ("sku", "nome", "descricao", "valor", "imagem_url", "ativo", "quantidade") VALUES
+('CK001', 'Cookie Clássico com Gotas de Chocolate', 'Massa amanteigada com baunilha e gotas de chocolate meio amargo.', 41.50, 'https://static.ifood-static.com.br/image/upload/t_medium/pratos/96aa4ce9-22d9-4993-8f81-01caf03c2d31/202506161754_8J5A_i.jpg', true, 10),
+('CK002', 'Cookie Chocolate Branco', 'Prepare-se para uma verdadeira explosão de sabores com o nosso irresistível Cookie de chocolate branco! ', 15.50, 'https://static.ifood-static.com.br/image/upload/t_medium/pratos/96aa4ce9-22d9-4993-8f81-01caf03c2d31/202502272218_TE6C_i.jpg', true, 10),
+('CK003', 'Cookie Dark Chocolate', 'Uma verdadeira explosão de sabores para os chocólatras de plantão! Nossa massa rica e intensa em cacau é a base perfeita para pedaços generosos de chocolate branco, ao leite e meio amargo, que se derretem delicadamente em cada mordida.', 52.50, 'https://static.ifood-static.com.br/image/upload/t_medium/pratos/96aa4ce9-22d9-4993-8f81-01caf03c2d31/202506161756_NB65_i.jpg', true, 10),
+('CK004', 'Cookie Nozes com Doce de Leite', 'Mergulhe em um mundo de sabor com o nosso Cookie de Nozes com Doce de Leite, uma verdadeira obra-prima que vai encantar seus sentidos! ', 17.90, 'https://static.ifood-static.com.br/image/upload/t_medium/pratos/96aa4ce9-22d9-4993-8f81-01caf03c2d31/202506161909_5T2Y_i.jpg', true, 10),
+('CK005', 'Cookie Romeu e Julieta', 'Uma releitura irresistível do clássico brasileiro!', 15.90, 'https://static.ifood-static.com.br/image/upload/t_medium/pratos/96aa4ce9-22d9-4993-8f81-01caf03c2d31/202506162235_DC6F_i.jpg', true, 10),
+('BL001', 'Brownie com Nutella', 'Marmitinha de brownie com um delicioso recheio de Nutella', 20.90, 'https://static.ifood-static.com.br/image/upload/t_medium/pratos/96aa4ce9-22d9-4993-8f81-01caf03c2d31/202502272219_4KDY_i.jpg', true, 10),
+('BL002', 'Bolo de Chocolate Intenso (fatia)', 'Fatia generosa de bolo de chocolate com cobertura de brigadeiro.', 35.00, 'https://static.ifood-static.com.br/image/upload/t_medium/pratos/96aa4ce9-22d9-4993-8f81-01caf03c2d31/202508091609_49LG_.jpeg', true, 10),
+('BL003', 'Bolo de Cenoura com Chocolate (inteiro)', 'Bolo fofinho de cenoura com cobertura de chocolate. Serve 8 pessoas.', 25.00, 'https://static.ifood-static.com.br/image/upload/t_medium/pratos/96aa4ce9-22d9-4993-8f81-01caf03c2d31/202508091609_49LG_.jpeg', true, 10);
 
 INSERT INTO "produto_ingrediente" ("produto_sku", "ingrediente_id", "quantidade_utilizada") VALUES
 ('CK001', 1, 0.5),
@@ -184,8 +171,8 @@ INSERT INTO "historico_compra" ("id_insumo", "id_unidade", "quantidade", "peco_u
 
 INSERT INTO "pedido" ("cliente_id", "data_criacao", "valor_total", "status", "cupom_id") VALUES
 ('1', '2025-09-26 14:00:00', 13.00, 'ENTREGUE', 2),
-('1', '2025-09-27 18:10:00', 45.00, 'PAGAMENTO_APROVADO', 3),
-('2', NOW(), 22.00, 'EM_PREPARACAO', NULL);
+('1', '2025-09-27 18:10:00', 45.00, 'PREPARANDO', 3),
+('2', NOW(), 22.00, 'ACEITO', NULL);
 
 INSERT INTO "pedido_item" ("pedido_id", "produto_sku", "quantidade", "valor_unitario") VALUES
 (1, 'CK001', 4, 4.50),

--- a/src/main/java/com/sedocefosse/backend/configs/aws/S3Config.java
+++ b/src/main/java/com/sedocefosse/backend/configs/aws/S3Config.java
@@ -1,0 +1,36 @@
+package com.sedocefosse.backend.configs.aws;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+
+@Configuration
+public class S3Config {
+
+    @Value("${aws.access-key-id}")
+    private String accessKeyId;
+
+    @Value("${aws.secret-access-key}")
+    private String secretAccessKey;
+
+    @Value("${aws.s3.region}")
+    private String region;
+
+    @Bean
+    public S3Client s3Client() {
+        AwsBasicCredentials awsCredentials = AwsBasicCredentials.create(
+            accessKeyId,
+            secretAccessKey
+        );
+
+        return S3Client.builder()
+                .region(Region.of(region))
+                .credentialsProvider(StaticCredentialsProvider.create(awsCredentials))
+                .build();
+    }
+}
+

--- a/src/main/java/com/sedocefosse/backend/configs/exceptions/FileUploadException.java
+++ b/src/main/java/com/sedocefosse/backend/configs/exceptions/FileUploadException.java
@@ -1,0 +1,16 @@
+package com.sedocefosse.backend.configs.exceptions;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.BAD_REQUEST)
+public class FileUploadException extends RuntimeException {
+    public FileUploadException(String message) {
+        super(message);
+    }
+
+    public FileUploadException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}
+

--- a/src/main/java/com/sedocefosse/backend/configs/exceptions/GlobalExceptionHandler.java
+++ b/src/main/java/com/sedocefosse/backend/configs/exceptions/GlobalExceptionHandler.java
@@ -23,6 +23,12 @@ public class GlobalExceptionHandler {
     public ResponseEntity<Map<String, Object>> handleResourceInUse(ResourceInUseException ex, WebRequest request) {
         return buildErrorResponse(HttpStatus.BAD_REQUEST, "Resource In Use", ex.getMessage(), request);
     }
+
+    @ExceptionHandler(FileUploadException.class)
+    public ResponseEntity<Map<String, Object>> handleFileUploadException(
+            FileUploadException ex, WebRequest request) {
+        return buildErrorResponse(HttpStatus.BAD_REQUEST, "File Upload Error", ex.getMessage(), request);
+    }
     
     private ResponseEntity<Map<String, Object>> buildErrorResponse(HttpStatus status, String error, String message, WebRequest request) {
         Map<String, Object> response = new HashMap<>();

--- a/src/main/java/com/sedocefosse/backend/controller/admin/AdminProductController.java
+++ b/src/main/java/com/sedocefosse/backend/controller/admin/AdminProductController.java
@@ -2,9 +2,8 @@ package com.sedocefosse.backend.controller.admin;
 
 import com.sedocefosse.backend.dto.CategoryDTO;
 import com.sedocefosse.backend.dto.ProductDTO;
-import com.sedocefosse.backend.dto.ProductDetailsDTO;
-import com.sedocefosse.backend.dto.ProductsResponseDTO;
 import com.sedocefosse.backend.model.Product;
+import com.sedocefosse.backend.service.aws.S3Service;
 import com.sedocefosse.backend.service.products.ProductService;
 
 import java.util.List;
@@ -21,8 +20,10 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequestMapping("admin/products")
@@ -31,14 +32,52 @@ public class AdminProductController {
     @Autowired
     private ProductService productService;
 
+    @Autowired
+    private S3Service s3Service;
+
     @DeleteMapping("/{sku}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void deleteProduct(@PathVariable String sku) {
         productService.deleteProductById(sku);
     }
 
-    @PostMapping
+    @PostMapping(consumes = "application/json")
     public ResponseEntity<ProductDTO> createProduct(@RequestBody ProductDTO product) {
+        ProductDTO createdProduct = productService.create(product);
+        return new ResponseEntity<>(createdProduct, HttpStatus.CREATED);
+    }
+
+    @PostMapping(consumes = "multipart/form-data")
+    public ResponseEntity<ProductDTO> createProductWithImage(
+            @RequestParam(value = "name", required = false) String name,
+            @RequestParam(value = "description", required = false) String description,
+            @RequestParam(value = "price", required = false) String price,
+            @RequestParam(value = "quantity", required = false) Integer quantity,
+            @RequestParam(value = "isActive", required = false) Boolean isActive,
+            @RequestParam(value = "categoryId", required = false) String categoryId,
+            @RequestParam(value = "imageSrc", required = false) MultipartFile imageFile) {
+        
+        ProductDTO.ProductDTOBuilder builder = ProductDTO.builder()
+                .name(name)
+                .description(description)
+                .price(price)
+                .quantity(quantity)
+                .isActive(isActive);
+        
+        if (categoryId != null && !categoryId.isEmpty()) {
+            builder.category(new CategoryDTO(categoryId, null, null));
+        }
+        
+        if (imageFile != null && !imageFile.isEmpty()) {
+            try {
+                String imageUrl = s3Service.uploadImage(imageFile, "produtos");
+                builder.imageSrc(imageUrl);
+            } catch (Exception e) {
+                return new ResponseEntity<>(null, HttpStatus.BAD_REQUEST);
+            }
+        }
+        
+        ProductDTO product = builder.build();
         ProductDTO createdProduct = productService.create(product);
         return new ResponseEntity<>(createdProduct, HttpStatus.CREATED);
     }
@@ -52,8 +91,55 @@ public class AdminProductController {
         return ResponseEntity.ok(updatedProduct);
     }
     
-    @PutMapping("/{sku}")
+    @PutMapping(value = "/{sku}", consumes = "application/json")
     public ResponseEntity<ProductDTO> updateProduct(@PathVariable String sku, @RequestBody ProductDTO productDetails) {
+        ProductDTO updatedProduct = productService.updateProduct(sku, productDetails);
+        return ResponseEntity.ok(updatedProduct);
+    }
+
+    @PutMapping(value = "/{sku}", consumes = "multipart/form-data")
+    public ResponseEntity<ProductDTO> updateProductWithImage(
+            @PathVariable String sku,
+            @RequestParam(value = "name", required = false) String name,
+            @RequestParam(value = "description", required = false) String description,
+            @RequestParam(value = "price", required = false) String price,
+            @RequestParam(value = "quantity", required = false) Integer quantity,
+            @RequestParam(value = "isActive", required = false) Boolean isActive,
+            @RequestParam(value = "categoryId", required = false) String categoryId,
+            @RequestParam(value = "imageSrc", required = false) MultipartFile imageFile) {
+        
+        ProductDTO.ProductDTOBuilder builder = ProductDTO.builder();
+        if (name != null) builder.name(name);
+        if (description != null) builder.description(description);
+        if (price != null) builder.price(price);
+        if (quantity != null) builder.quantity(quantity);
+        if (isActive != null) builder.isActive(isActive);
+        
+        if (categoryId != null && !categoryId.isEmpty()) {
+            builder.category(new CategoryDTO(categoryId, null, null));
+        }
+        
+        if (imageFile != null && !imageFile.isEmpty()) {
+            try {
+                // Deletar imagem antiga
+                Optional<ProductDTO> currentProduct = productService.findProductBySku(sku);
+                if (currentProduct.isPresent() && currentProduct.get().getImageSrc() != null 
+                        && currentProduct.get().getImageSrc().contains("amazonaws.com")) {
+                    try {
+                        s3Service.deleteImage(currentProduct.get().getImageSrc());
+                    } catch (Exception e) {
+                        System.err.println("Erro ao deletar imagem antiga: " + e.getMessage());
+                    }
+                }
+                
+                String imageUrl = s3Service.uploadImage(imageFile, "produtos/" + sku);
+                builder.imageSrc(imageUrl);
+            } catch (Exception e) {
+                return new ResponseEntity<>(null, HttpStatus.BAD_REQUEST);
+            }
+        }
+        
+        ProductDTO productDetails = builder.build();
         ProductDTO updatedProduct = productService.updateProduct(sku, productDetails);
         return ResponseEntity.ok(updatedProduct);
     }

--- a/src/main/java/com/sedocefosse/backend/service/aws/S3Service.java
+++ b/src/main/java/com/sedocefosse/backend/service/aws/S3Service.java
@@ -1,0 +1,11 @@
+package com.sedocefosse.backend.service.aws;
+
+import org.springframework.web.multipart.MultipartFile;
+
+public interface S3Service {
+    String uploadImage(MultipartFile file, String folder);
+    String uploadImage(MultipartFile file, String folder, String fileName);
+    String uploadImageFromBase64(String base64Image, String folder);
+    void deleteImage(String imageUrl);
+}
+

--- a/src/main/java/com/sedocefosse/backend/service/aws/S3ServiceImpl.java
+++ b/src/main/java/com/sedocefosse/backend/service/aws/S3ServiceImpl.java
@@ -1,0 +1,221 @@
+package com.sedocefosse.backend.service.aws;
+
+import com.sedocefosse.backend.configs.exceptions.FileUploadException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.ObjectCannedACL;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.S3Exception;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.List;
+import java.util.UUID;
+
+@Slf4j
+@Service
+public class S3ServiceImpl implements S3Service {
+
+    private final S3Client s3Client;
+
+    @Value("${aws.s3.bucket-name}")
+    private String bucketName;
+
+    @Value("${aws.s3.region}")
+    private String region;
+
+    public S3ServiceImpl(S3Client s3Client) {
+        this.s3Client = s3Client;
+    }
+
+    private static final List<String> ALLOWED_CONTENT_TYPES = Arrays.asList(
+            "image/jpeg",
+            "image/jpg",
+            "image/png",
+            "image/webp"
+    );
+
+    private static final long MAX_FILE_SIZE = 5 * 1024 * 1024;
+
+    @Override
+    public String uploadImage(MultipartFile file, String folder) {
+        String fileName = generateFileName(file.getOriginalFilename());
+        return uploadImage(file, folder, fileName);
+    }
+
+    @Override
+    public String uploadImage(MultipartFile file, String folder, String fileName) {
+        validateFile(file);
+
+        try {
+            String key = folder != null && !folder.isEmpty() 
+                    ? folder + "/" + fileName 
+                    : fileName;
+
+            String contentType = file.getContentType();
+            if (contentType == null) {
+                contentType = "image/jpeg"; // Default
+            }
+
+            PutObjectRequest putObjectRequest = PutObjectRequest.builder()
+                    .bucket(bucketName)
+                    .key(key)
+                    .contentType(contentType)
+                    .acl(ObjectCannedACL.PUBLIC_READ)
+                    .build();
+
+            s3Client.putObject(putObjectRequest, RequestBody.fromInputStream(
+                    file.getInputStream(), file.getSize()));
+
+            String imageUrl = String.format("https://%s.s3.%s.amazonaws.com/%s",
+                    bucketName,
+                    region,
+                    key);
+
+            log.info("Imagem enviada com sucesso para S3: {}", imageUrl);
+            return imageUrl;
+
+        } catch (IOException e) {
+            log.error("Erro ao ler o arquivo: {}", e.getMessage());
+            throw new FileUploadException("Erro ao processar o arquivo: " + e.getMessage(), e);
+        } catch (S3Exception e) {
+            log.error("Erro ao fazer upload para S3: {}", e.getMessage());
+            throw new FileUploadException("Erro ao fazer upload para S3: " + e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public String uploadImageFromBase64(String base64Image, String folder) {
+        try {
+            String base64Data = base64Image;
+            String contentType = "image/jpeg"; 
+            String extension = ".jpg";
+            
+            if (base64Image.contains(",")) {
+                String[] parts = base64Image.split(",");
+                base64Data = parts[1];
+                
+                String prefix = parts[0];
+                if (prefix.contains("image/jpeg") || prefix.contains("image/jpg")) {
+                    contentType = "image/jpeg";
+                    extension = ".jpg";
+                } else if (prefix.contains("image/png")) {
+                    contentType = "image/png";
+                    extension = ".png";
+                } else if (prefix.contains("image/webp")) {
+                    contentType = "image/webp";
+                    extension = ".webp";
+                }
+            }
+            
+            byte[] imageBytes = Base64.getDecoder().decode(base64Data);
+            
+            if (imageBytes.length > MAX_FILE_SIZE) {
+                throw new FileUploadException("Arquivo muito grande. Tamanho máximo permitido: 5MB");
+            }
+            
+            String fileName = generateFileName("image" + extension);
+            String key = folder != null && !folder.isEmpty() 
+                    ? folder + "/" + fileName 
+                    : fileName;
+            
+            PutObjectRequest putObjectRequest = PutObjectRequest.builder()
+                    .bucket(bucketName)
+                    .key(key)
+                    .contentType(contentType)
+                    .acl(ObjectCannedACL.PUBLIC_READ)
+                    .build();
+            
+            s3Client.putObject(putObjectRequest, RequestBody.fromInputStream(
+                    new ByteArrayInputStream(imageBytes), imageBytes.length));
+            
+            String imageUrl = String.format("https://%s.s3.%s.amazonaws.com/%s",
+                    bucketName,
+                    region,
+                    key);
+            
+            log.info("Imagem enviada com sucesso para S3 a partir de Base64: {}", imageUrl);
+            return imageUrl;
+            
+        } catch (IllegalArgumentException e) {
+            log.error("Erro ao decodificar Base64: {}", e.getMessage());
+            throw new FileUploadException("Formato Base64 inválido: " + e.getMessage(), e);
+        } catch (S3Exception e) {
+            log.error("Erro ao fazer upload para S3: {}", e.getMessage());
+            throw new FileUploadException("Erro ao fazer upload para S3: " + e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public void deleteImage(String imageUrl) {
+        try {
+            String key = extractKeyFromUrl(imageUrl);
+
+            DeleteObjectRequest deleteObjectRequest = DeleteObjectRequest.builder()
+                    .bucket(bucketName)
+                    .key(key)
+                    .build();
+
+            s3Client.deleteObject(deleteObjectRequest);
+            log.info("Imagem deletada com sucesso do S3: {}", key);
+
+        } catch (S3Exception e) {
+            log.error("Erro ao deletar imagem do S3: {}", e.getMessage());
+            throw new FileUploadException("Erro ao deletar imagem do S3: " + e.getMessage(), e);
+        }
+    }
+
+    private void validateFile(MultipartFile file) {
+        if (file == null || file.isEmpty()) {
+            throw new FileUploadException("Arquivo não pode ser vazio");
+        }
+
+        String contentType = file.getContentType();
+        if (contentType == null || !ALLOWED_CONTENT_TYPES.contains(contentType.toLowerCase())) {
+            throw new FileUploadException(
+                    "Tipo de arquivo não permitido. Use apenas: JPG, PNG ou WEBP");
+        }
+
+        if (file.getSize() > MAX_FILE_SIZE) {
+            throw new FileUploadException(
+                    "Arquivo muito grande. Tamanho máximo permitido: 5MB");
+        }
+    }
+
+    private String generateFileName(String originalFilename) {
+        String extension = "";
+        if (originalFilename != null && originalFilename.contains(".")) {
+            extension = originalFilename.substring(originalFilename.lastIndexOf("."));
+        } else {
+            extension = ".jpg"; 
+        }
+
+        String timestamp = LocalDateTime.now()
+                .format(DateTimeFormatter.ofPattern("yyyyMMddHHmmss"));
+        String uuid = UUID.randomUUID().toString().substring(0, 8);
+
+        return timestamp + "-" + uuid + extension;
+    }
+
+    private String extractKeyFromUrl(String imageUrl) {
+        try {
+            String[] parts = imageUrl.split(".amazonaws.com/");
+            if (parts.length > 1) {
+                return parts[1];
+            }
+            throw new FileUploadException("URL de imagem inválida");
+        } catch (Exception e) {
+            throw new FileUploadException("Erro ao extrair chave da URL: " + e.getMessage());
+        }
+    }
+}
+

--- a/src/main/java/com/sedocefosse/backend/service/products/ProductServiceImpl.java
+++ b/src/main/java/com/sedocefosse/backend/service/products/ProductServiceImpl.java
@@ -14,6 +14,7 @@ import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import com.sedocefosse.backend.configs.exceptions.ResourceNotFoundException;
+import com.sedocefosse.backend.service.aws.S3Service;
 import com.sedocefosse.backend.dto.CategoryDTO;
 import com.sedocefosse.backend.dto.ProductDTO;
 import com.sedocefosse.backend.dto.ProductDetailsDTO;
@@ -32,11 +33,22 @@ public class ProductServiceImpl implements ProductService {
     private final CategoryRepository categoryRepository;
     private final ProductSupplyService productSupplyService;
     private final OrderRepository orderRepository;
+    private final S3Service s3Service;
 
     @Override
     @Transactional
     public ProductDTO create(ProductDTO product) {        
         product.setSku(UUID.randomUUID().toString());
+
+        String imageUrl = product.getImageSrc();
+        if (imageUrl != null && isBase64Image(imageUrl)) {
+            try {
+                imageUrl = s3Service.uploadImageFromBase64(imageUrl, "produtos");
+                product.setImageSrc(imageUrl);
+            } catch (Exception e) {
+                System.err.println("Erro ao fazer upload da imagem para S3: " + e.getMessage());
+            }
+        }
 
         Product newProduct = new Product();
         newProduct.setSku(product.getSku());
@@ -44,7 +56,7 @@ public class ProductServiceImpl implements ProductService {
         newProduct.setDescricao(product.getDescription());
         newProduct.setValor(new BigDecimal(product.getPrice()));
         newProduct.setQuantidade(product.getQuantity());
-        newProduct.setImagemUrl(product.getImageSrc());
+        newProduct.setImagemUrl(imageUrl);
         newProduct.setAtivo(product.getIsActive());
 
         Product savedProduct = productRepository.save(newProduct);
@@ -217,7 +229,27 @@ public class ProductServiceImpl implements ProductService {
             product.setValor(new BigDecimal(productDto.getPrice().replace("R$ ", "").replace(",", ".")));
         }
         if (productDto.getImageSrc() != null) {
-            product.setImagemUrl(productDto.getImageSrc());
+            String imageUrl = productDto.getImageSrc();
+            
+            if (isBase64Image(imageUrl)) {
+                try {
+                    // Deletar imagem antiga
+                    if (product.getImagemUrl() != null && product.getImagemUrl().contains("amazonaws.com")) {
+                        try {
+                            s3Service.deleteImage(product.getImagemUrl());
+                        } catch (Exception e) {
+                            System.err.println("Erro ao deletar imagem antiga: " + e.getMessage());
+                        }
+                    }
+                    
+                    imageUrl = s3Service.uploadImageFromBase64(imageUrl, "produtos/" + sku);
+                    productDto.setImageSrc(imageUrl);
+                } catch (Exception e) {
+                    System.err.println("Erro ao fazer upload da imagem para S3: " + e.getMessage());
+                }
+            }
+            
+            product.setImagemUrl(imageUrl);
         }
         if (productDto.getIsActive() != null) {
             product.setAtivo(productDto.getIsActive());
@@ -280,14 +312,21 @@ public class ProductServiceImpl implements ProductService {
         newCategory.setProdutos(produtos);
         categoryRepository.save(newCategory);
     }
+
+    private boolean isBase64Image(String imageSrc) {
+        if (imageSrc == null || imageSrc.isEmpty()) {
+            return false;
+        }
+        
+        if (imageSrc.startsWith("data:image/")) {
+            return true;
+        }
+        
+        if (imageSrc.startsWith("http://") || imageSrc.startsWith("https://")) {
+            return false;
+        }
+        
+        return false;
+    }
 }
 
-//Teste manual a ser feito no Postman
-//POST http://localhost:8080/api/products
-//Body (JSON):
-// {
-//     "name": "Produto Exemplo",
-//     "description": "Descrição do Produto Exemplo",
-//     "price": 19.99,
-//     "imageUrl": "http://exemplo.com/imagem.jpg",
-//     "restricaoAlimentar": "Sem glúten"

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,6 +1,6 @@
 spring.application.name=backend
 
-spring.config.import=file:.env[.properties]
+spring.config.import=optional:file:.env[.properties]
 
 spring.datasource.url=jdbc:postgresql://postgres:5432/db-se-doce-fosse
 spring.datasource.driverClassName=org.postgresql.Driver

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,5 +1,7 @@
 spring.application.name=backend
 
+spring.config.import=file:.env[.properties]
+
 spring.datasource.url=jdbc:postgresql://postgres:5432/db-se-doce-fosse
 spring.datasource.driverClassName=org.postgresql.Driver
 spring.datasource.username=admin
@@ -24,3 +26,8 @@ spring.data.mongodb.uri=mongodb://mongouser:mongopassword@mongo:27017/db-se-doce
 spring.data.mongodb.database=db-se-doce-fosse
 
 api.security.token.secret=U29tZVN1cGVyU2VjcmV0S2V5MTIzIQ==
+
+aws.s3.bucket-name=${AWS_S3_BUCKET_NAME:se-doce-fosse-images}
+aws.s3.region=${AWS_S3_REGION:us-east-2}
+aws.access-key-id=${AWS_ACCESS_KEY_ID}
+aws.secret-access-key=${AWS_SECRET_ACCESS_KEY}

--- a/src/test/java/com/sedocefosse/backend/controller/AdminProductControllerTest.java
+++ b/src/test/java/com/sedocefosse/backend/controller/AdminProductControllerTest.java
@@ -6,12 +6,14 @@ import com.sedocefosse.backend.controller.admin.AdminProductController;
 import com.sedocefosse.backend.model.Category;
 import com.sedocefosse.backend.model.Product;
 import com.sedocefosse.backend.repository.admin.AdminRepository;
+import com.sedocefosse.backend.service.aws.S3Service;
 import com.sedocefosse.backend.service.products.ProductService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.math.BigDecimal;
@@ -29,6 +31,12 @@ import com.sedocefosse.backend.dto.ProductDetailsDTO;
 
 
 @WebMvcTest(AdminProductController.class)
+@TestPropertySource(properties = {
+    "aws.s3.bucket-name=test-bucket",
+    "aws.s3.region=us-east-1",
+    "aws.access-key-id=test-access-key",
+    "aws.secret-access-key=test-secret-key"
+})
 class AdminProductControllerTest {
 
     @Autowired
@@ -42,6 +50,9 @@ class AdminProductControllerTest {
 
     @MockBean
     private AdminRepository adminRepository;
+
+    @MockBean
+    private S3Service s3Service;
 
     @Autowired
     private ObjectMapper objectMapper;

--- a/src/test/java/com/sedocefosse/backend/controller/AdminProductControllerTest.java
+++ b/src/test/java/com/sedocefosse/backend/controller/AdminProductControllerTest.java
@@ -15,6 +15,7 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
+import software.amazon.awssdk.services.s3.S3Client;
 
 import java.math.BigDecimal;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
@@ -53,6 +54,9 @@ class AdminProductControllerTest {
 
     @MockBean
     private S3Service s3Service;
+
+    @MockBean
+    private S3Client s3Client;
 
     @Autowired
     private ObjectMapper objectMapper;

--- a/src/test/java/com/sedocefosse/backend/controller/LoginControllerTest.java
+++ b/src/test/java/com/sedocefosse/backend/controller/LoginControllerTest.java
@@ -10,6 +10,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
 
 import static org.mockito.ArgumentMatchers.anyString;
@@ -19,6 +20,12 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(LoginController.class)
+@TestPropertySource(properties = {
+    "aws.s3.bucket-name=test-bucket",
+    "aws.s3.region=us-east-1",
+    "aws.access-key-id=test-access-key",
+    "aws.secret-access-key=test-secret-key"
+})
 class LoginControllerTest {
 
     @Autowired

--- a/src/test/java/com/sedocefosse/backend/controller/LoginControllerTest.java
+++ b/src/test/java/com/sedocefosse/backend/controller/LoginControllerTest.java
@@ -12,6 +12,7 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
+import software.amazon.awssdk.services.s3.S3Client;
 
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
@@ -42,6 +43,9 @@ class LoginControllerTest {
 
     @MockBean
     private AdminRepository adminRepository;
+
+    @MockBean
+    private S3Client s3Client;
 
     @Test
     void login_shouldReturnExistingCustomer_orCreateAndReturn() throws Exception {

--- a/src/test/java/com/sedocefosse/backend/controller/ProductControllerTest.java
+++ b/src/test/java/com/sedocefosse/backend/controller/ProductControllerTest.java
@@ -10,6 +10,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
+import software.amazon.awssdk.services.s3.S3Client;
 
 import java.math.BigDecimal;
 import java.util.Optional;
@@ -48,6 +49,9 @@ class ProductControllerTest {
 
     @MockBean
     private AdminRepository adminRepository;
+
+    @MockBean
+    private S3Client s3Client;
 
     // @Test
     // void getProductBySku_shouldReturnProduct_whenSkuExists() throws Exception {

--- a/src/test/java/com/sedocefosse/backend/controller/ProductControllerTest.java
+++ b/src/test/java/com/sedocefosse/backend/controller/ProductControllerTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.math.BigDecimal;
@@ -28,6 +29,12 @@ import java.util.Arrays;
 import java.util.List;
 
 @WebMvcTest(ProductController.class)
+@TestPropertySource(properties = {
+    "aws.s3.bucket-name=test-bucket",
+    "aws.s3.region=us-east-1",
+    "aws.access-key-id=test-access-key",
+    "aws.secret-access-key=test-secret-key"
+})
 class ProductControllerTest {
 
     @Autowired

--- a/src/test/java/com/sedocefosse/backend/controller/SupplyControllerTest.java
+++ b/src/test/java/com/sedocefosse/backend/controller/SupplyControllerTest.java
@@ -4,6 +4,7 @@ import com.sedocefosse.backend.controller.admin.SupplyController;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -15,6 +16,12 @@ import static org.hamcrest.Matchers.is;
 import com.sedocefosse.backend.service.products.SupplyService;
 
 @WebMvcTest(SupplyController.class)
+@TestPropertySource(properties = {
+    "aws.s3.bucket-name=test-bucket",
+    "aws.s3.region=us-east-1",
+    "aws.access-key-id=test-access-key",
+    "aws.secret-access-key=test-secret-key"
+})
 class SupplyControllerTest {
 
     @Autowired

--- a/src/test/java/com/sedocefosse/backend/controller/SupplyControllerTest.java
+++ b/src/test/java/com/sedocefosse/backend/controller/SupplyControllerTest.java
@@ -6,6 +6,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
+import software.amazon.awssdk.services.s3.S3Client;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -29,6 +30,9 @@ class SupplyControllerTest {
 
     @MockBean
     private SupplyService supplyService;
+
+    @MockBean
+    private S3Client s3Client;
 
     // @Test
     // void ShouldFindAllSuppliesReturnOK() throws Exception {

--- a/src/test/resources/application-test.properties
+++ b/src/test/resources/application-test.properties
@@ -1,0 +1,6 @@
+# valores mock para AWS S3
+aws.s3.bucket-name=test-bucket
+aws.s3.region=us-east-1
+aws.access-key-id=test-access-key
+aws.secret-access-key=test-secret-key
+


### PR DESCRIPTION
## Integração com **AWS S3**
- Suporte a **multipart/form-data** (arquivo) 
- Imagens organizadas no S3 e URLs salvas no banco  

---

## Como usar

### 📌 Criar produto com imagem 

**POST** `http://18.224.78.94:8081/admin/products`  
**Content-Type:** `multipart/form-data`

**Body (form-data):**
- `name`: Cookie Clássico  
- `description`: Delicioso cookie com gotas de chocolate  
- `price`: 15.90  
- `quantity`: 10  
- `isActive`: true  
- `categoryId`: cat001 (opcional)  
- `imageSrc`: *(selecione arquivo JPG/PNG/WEBP)*  

---

### 📌 Atualizar produto com nova imagem

**PUT** `http://18.224.78.94:8081/admin/products/{sku}`  
**Content-Type:** `multipart/form-data`

**Body (form-data):**
- `imageSrc`: (nova imagem)

---


## Configuração necessária

Crie um arquivo **`.env`** na raiz do projeto com as credenciais AWS  